### PR TITLE
Update __init__.py

### DIFF
--- a/back/taiga_contrib_github_auth/__init__.py
+++ b/back/taiga_contrib_github_auth/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (C) 2014 Andrey Antukh <niwi@niwi.be>
 # Copyright (C) 2014 Jesús Espino <jespinog@gmail.com>
 # Copyright (C) 2014 David Barragán <bameda@dbarragan.com>


### PR DESCRIPTION
pip install is failing with:

SyntaxError: Non-ASCII character '\xc3' in file /home/platform/taiga-scripts/taiga-contrib-github-auth/back/taiga_contrib_github_auth/__init__.py on line 2, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details

due to this