### PR TITLE
Prototype of a (working) Gitlab/OAuth2 backend

### DIFF
--- a/back/taiga_contrib_github_auth/apps.py
+++ b/back/taiga_contrib_github_auth/apps.py
@@ -27,4 +27,5 @@ class TaigaContribGithubAuthAppConfig(AppConfig):
 
     def ready(self):
         register_auth_plugin("github", services.github_login_func)
+        register_auth_plugin("gitlab", services.gitlab_login_func)
 

--- a/back/taiga_contrib_github_auth/services.py
+++ b/back/taiga_contrib_github_auth/services.py
@@ -81,3 +81,18 @@ def github_login_func(request):
                            token=token)
     data = make_auth_response_data(user)
     return data
+
+def gitlab_login_func(request):
+    code = request.DATA.get('code', None)
+    token = request.DATA.get('token', None)
+
+    email, user_info = connector.me_gitlab(code)
+
+    user = github_register(username=user_info.username,
+                           email=email,
+                           full_name=user_info.full_name,
+                           github_id=user_info.id,
+                           bio=user_info.bio,
+                           token=token)
+    data = make_auth_response_data(user)
+    return data


### PR DESCRIPTION
This is not meant to be merged (code is horrible), but it is merely a hack showing a working backend implementation for Gitlab. Frontend needs a minimal change in the GET URL (not configurable as of now).

This PR is merely a "it can be done easily", I'll be glad to work on it depending on where you think this belongs. Should I clone the plugin or add the Gitlab feature to this? I think the best option is to make this a generic OAuth2 authentication backend, and add providers as we go.